### PR TITLE
Check for failure of realloc

### DIFF
--- a/fanout.c
+++ b/fanout.c
@@ -677,6 +677,8 @@ void str_swap_free (char **target, char *source)
 
 char *str_append (char *target, const char *data)
 {
+    char *newtarget;
+
     if (data == NULL) {
         return target;
     }
@@ -687,9 +689,14 @@ char *str_append (char *target, const char *data)
     }
 
     int len = strlen (target) + strlen (data) + 1;
-    target = realloc (target, len);
+    newtarget = realloc (target, len);
+    if (newtarget == NULL) {
+        fanout_error ("ERROR unable to allocate memory");
+        exit (EXIT_FAILURE);
+    }
+    newtarget = strcat (newtarget, data);
 
-    return strcat (target, data);
+    return newtarget;
 }
 
 


### PR DESCRIPTION
Check for the (unlikely) failure of realloc and exit if it happens. This prevents a cppcheck warning about a memory leak.
