### PR TITLE
Zero out epoll_event struct before using it - prevents valgrind warnings

### DIFF
--- a/fanout.c
+++ b/fanout.c
@@ -343,6 +343,7 @@ xit\n");
     struct epoll_event fds[nfds];
 
     for (nfds = 0, runp = ai; runp != NULL; runp = runp->ai_next)  {
+        memset(&fds[nfds], 0, sizeof(struct epoll_event));
         fds[nfds].data.fd = socket (runp->ai_family, runp->ai_socktype, runp->ai_protocol);
         if (fds[nfds].data.fd == -1) {
             fanout_error ("ERROR opening socket");


### PR DESCRIPTION
Some of the elements of the epoll_event struct don't get set before passing it to epoll_ctl. This fixes a valgrind warning about using uninitialized memory.
