### PR TITLE
Fix compiler warning about logical-not & parentheses

### DIFF
--- a/fanout.c
+++ b/fanout.c
@@ -317,7 +317,7 @@ xit\n");
         exit (EXIT_FAILURE);
     }
 
-    if ( ! portno > 0) {
+    if ( ! (portno < 0)) {
         fanout_debug (0, "ERROR invalid port\n");
         exit (EXIT_FAILURE);
     }


### PR DESCRIPTION
I get this warning when compiling:
```$ make
cc -std=c99 -Wall -g    fanout.c   -o fanout
fanout.c: In function 'main':
fanout.c:320:19: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
     if ( ! portno > 0) {
                   ^
```

This is on GCC (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609